### PR TITLE
add optional context.Context parameter to handlers

### DIFF
--- a/webhook/handler_test.go
+++ b/webhook/handler_test.go
@@ -9,6 +9,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 const secret = "dupa.8"
@@ -29,12 +31,13 @@ func (Bar) Other()              {}
 
 type Baz struct{}
 
-func (Baz) All(string, interface{})   {}
-func (Baz) Delete(*DeleteEvent)       {}
-func (Baz) ForkApply(*ForkApplyEvent) {}
-func (Baz) Gollum(*GollumEvent)       {}
-func (Baz) gollum(*GollumEvent)       {}
-func (Baz) Add(int, int) int          { return 0 }
+func (Baz) All(string, interface{})              {}
+func (Baz) Delete(*DeleteEvent)                  {}
+func (Baz) ForkApply(*ForkApplyEvent)            {}
+func (Baz) Gollum(*GollumEvent)                  {}
+func (Baz) gollum(*GollumEvent)                  {}
+func (Baz) Create(context.Context, *CreateEvent) {}
+func (Baz) Add(int, int) int                     { return 0 }
 
 func TestPayloadMethods(t *testing.T) {
 	cases := [...]struct {
@@ -54,7 +57,7 @@ func TestPayloadMethods(t *testing.T) {
 		// i=2
 		{
 			Baz{},
-			[]string{"*", "delete", "fork_apply", "gollum"},
+			[]string{"*", "create", "delete", "fork_apply", "gollum"},
 		},
 	}
 	for i, cas := range cases {


### PR DESCRIPTION
In this PR we have introduced optional `context.Context` parameter for handlers. Our requirement was parsing http.Request and injecting data to handlers for each request as shown below:

```go
func (g Github) Push(ctx context.Context, e *webhook.PushEvent) {
    token := ctx.Value("token").(string)
}
```

For creating context data for each request, we have added `ContextFunc func(req *http.Request) context.Context` field to `handler`. Here is how it works:

1- When Context is added as an operand to handler, context data that is generated by `ContextFunc` is injected. If this function is not defined, then empty context (`context.Background()`) is used. 
2- When Context does not exist in the handler, it works as is. In this case `ContextFunc` is not used at all, even if the user defines it. 

